### PR TITLE
fix a bunch of null references if a user is not in the guild

### DIFF
--- a/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
+++ b/DSharpPlus.SlashCommands/SlashCommandsExtension.cs
@@ -366,11 +366,11 @@ namespace DSharpPlus.SlashCommands
                                     args.Add((bool)option.Value);
                                 else if (ReferenceEquals(parameter.ParameterType, typeof(DiscordUser)))
                                 {
-                                    if (e.Interaction.Data.Resolved.Members.TryGetValue((ulong)option.Value, out var member))
+                                    if (e.Interaction.Data.Resolved.Members != null && e.Interaction.Data.Resolved.Members.TryGetValue((ulong)option.Value, out var member))
                                     {
                                         args.Add(member);
                                     }
-                                    else if (e.Interaction.Data.Resolved.Users.TryGetValue((ulong)option.Value, out var user))
+                                    else if (e.Interaction.Data.Resolved.Users != null && e.Interaction.Data.Resolved.Users.TryGetValue((ulong)option.Value, out var user))
                                     {
                                         args.Add(user);
                                     }
@@ -434,11 +434,11 @@ namespace DSharpPlus.SlashCommands
                                     args.Add((bool)option.Value);
                                 else if (ReferenceEquals(parameter.ParameterType, typeof(DiscordUser)))
                                 {
-                                    if (e.Interaction.Data.Resolved.Members.TryGetValue((ulong)option.Value, out var member))
+                                    if (e.Interaction.Data.Resolved.Members != null && e.Interaction.Data.Resolved.Members.TryGetValue((ulong)option.Value, out var member))
                                     {
                                         args.Add(member);
                                     }
-                                    else if (e.Interaction.Data.Resolved.Users.TryGetValue((ulong)option.Value, out var user))
+                                    else if (e.Interaction.Data.Resolved.Users != null && e.Interaction.Data.Resolved.Users.TryGetValue((ulong)option.Value, out var user))
                                     {
                                         args.Add(user);
                                     }
@@ -504,11 +504,11 @@ namespace DSharpPlus.SlashCommands
                                     args.Add((bool)option.Value);
                                 else if (ReferenceEquals(parameter.ParameterType, typeof(DiscordUser)))
                                 {
-                                    if (e.Interaction.Data.Resolved.Members.TryGetValue((ulong)option.Value, out var member))
+                                    if (e.Interaction.Data.Resolved.Members != null && e.Interaction.Data.Resolved.Members.TryGetValue((ulong)option.Value, out var member))
                                     {
                                         args.Add(member);
                                     }
-                                    else if (e.Interaction.Data.Resolved.Users.TryGetValue((ulong)option.Value, out var user))
+                                    else if (e.Interaction.Data.Resolved.Users != null && e.Interaction.Data.Resolved.Users.TryGetValue((ulong)option.Value, out var user))
                                     {
                                         args.Add(user);
                                     }


### PR DESCRIPTION
Slash commands such as `/command <@63306150757543936>` will fail if the user is not in the guild, this is a fix for that by checking if the resolved interaction is null.